### PR TITLE
fix: Add missing index to boost the retrieve

### DIFF
--- a/resources/migrations/20241123234427_create_geolocation_table.up.sql
+++ b/resources/migrations/20241123234427_create_geolocation_table.up.sql
@@ -12,3 +12,5 @@ CREATE TABLE IF NOT EXISTS "geolocation" (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE UNIQUE INDEX geolocation_ip_address_idx ON geolocation(ip_address);


### PR DESCRIPTION
# Description

Adding missing index at ip_address column to improve query.

Added a unique index to avoid duplication of ip_address since assume that we will have only one record per ip_address.

**Note:**

- The assumption is to have only one record per `ip_address` to facilitate the scope of the test.

- I did update the SQL in the same file just because this is a task, but the process should be create a new migration file that contains this change. For example:

```
CREATE UNIQUE INDEX geolocation_ip_address_idx ON geolocation(ip_address);
```

**Extra:**

In case the retrieve select not for all the columns but for example `select latitude, longitude where ip_address =$1` it will be possible to use `INCLUDE (latitude, longitude)` avoiding base table lookups.

```
CREATE UNIQUE INDEX geolocation_ip_address_idx ON geolocation(ip_address) INCLUDE (latitude, longitude);
```

**Using sample data:**

Before index

```
QUERY PLAN                                                                   |
-----------------------------------------------------------------------------+
Gather  (cost=1000.00..19435.28 rows=3 width=66)                             |
  Workers Planned: 2                                                         |
  ->  Parallel Seq Scan on geolocation  (cost=0.00..18434.98 rows=1 width=66)|
        Filter: (ip_address = '89.207.159.171'::inet)                        |
```

After index:

```
QUERY PLAN                                                                                   |
---------------------------------------------------------------------------------------------+
Index Scan using geolocation_ip_address_idx on geolocation  (cost=0.42..8.44 rows=1 width=66)|
  Index Cond: (ip_address = '89.207.159.171'::inet)                                          |
``` 