### PR TITLE
fix: Add insert geolocation in batch

### DIFF
--- a/internal/domain/usecase/GeolocationDataProcessor_test.go
+++ b/internal/domain/usecase/GeolocationDataProcessor_test.go
@@ -36,7 +36,7 @@ func TestGeolocationDataProcessor_Process_all_success(t *testing.T) {
 
 	// storage
 	storage := mocks.NewGeolocationDataStorage(t)
-	storage.EXPECT().SaveGeolocation(mock.Anything, mock.AnythingOfType(reflect.TypeOf(model.Geolocation{}).String())).Return(nil).Times(len(data))
+	storage.EXPECT().SaveGeolocation(mock.Anything, mock.AnythingOfType(reflect.TypeOf(make([]*model.Geolocation, 0, 3)).String())).Return(nil).Once()
 
 	logger := &ctxd.LoggerMock{}
 
@@ -142,7 +142,7 @@ func TestGeolocationDataProcessor_Process(t *testing.T) {
 
 	// storage
 	storage := mocks.NewGeolocationDataStorage(t)
-	storage.EXPECT().SaveGeolocation(mock.Anything, mock.AnythingOfType(reflect.TypeOf(model.Geolocation{}).String())).Return(nil)
+	storage.EXPECT().SaveGeolocation(mock.Anything, mock.AnythingOfType(reflect.TypeOf(make([]*model.Geolocation, 0, 3)).String())).Return(nil)
 
 	logger := &ctxd.LoggerMock{}
 

--- a/internal/domain/usecase/mocks/geolocation_data_storage.go
+++ b/internal/domain/usecase/mocks/geolocation_data_storage.go
@@ -23,7 +23,7 @@ func (_m *GeolocationDataStorage) EXPECT() *GeolocationDataStorage_Expecter {
 }
 
 // SaveGeolocation provides a mock function with given fields: ctx, geo
-func (_m *GeolocationDataStorage) SaveGeolocation(ctx context.Context, geo model.Geolocation) error {
+func (_m *GeolocationDataStorage) SaveGeolocation(ctx context.Context, geo []*model.Geolocation) error {
 	ret := _m.Called(ctx, geo)
 
 	if len(ret) == 0 {
@@ -31,7 +31,7 @@ func (_m *GeolocationDataStorage) SaveGeolocation(ctx context.Context, geo model
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.Geolocation) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []*model.Geolocation) error); ok {
 		r0 = rf(ctx, geo)
 	} else {
 		r0 = ret.Error(0)
@@ -47,14 +47,14 @@ type GeolocationDataStorage_SaveGeolocation_Call struct {
 
 // SaveGeolocation is a helper method to define mock.On call
 //   - ctx context.Context
-//   - geo model.Geolocation
+//   - geo []*model.Geolocation
 func (_e *GeolocationDataStorage_Expecter) SaveGeolocation(ctx interface{}, geo interface{}) *GeolocationDataStorage_SaveGeolocation_Call {
 	return &GeolocationDataStorage_SaveGeolocation_Call{Call: _e.mock.On("SaveGeolocation", ctx, geo)}
 }
 
-func (_c *GeolocationDataStorage_SaveGeolocation_Call) Run(run func(ctx context.Context, geo model.Geolocation)) *GeolocationDataStorage_SaveGeolocation_Call {
+func (_c *GeolocationDataStorage_SaveGeolocation_Call) Run(run func(ctx context.Context, geo []*model.Geolocation)) *GeolocationDataStorage_SaveGeolocation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(model.Geolocation))
+		run(args[0].(context.Context), args[1].([]*model.Geolocation))
 	})
 	return _c
 }
@@ -64,7 +64,7 @@ func (_c *GeolocationDataStorage_SaveGeolocation_Call) Return(_a0 error) *Geoloc
 	return _c
 }
 
-func (_c *GeolocationDataStorage_SaveGeolocation_Call) RunAndReturn(run func(context.Context, model.Geolocation) error) *GeolocationDataStorage_SaveGeolocation_Call {
+func (_c *GeolocationDataStorage_SaveGeolocation_Call) RunAndReturn(run func(context.Context, []*model.Geolocation) error) *GeolocationDataStorage_SaveGeolocation_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/platform/storage/geolocation.go
+++ b/internal/platform/storage/geolocation.go
@@ -32,10 +32,10 @@ func NewGeolocation(storage *sqluct.Storage) *Geolocation {
 }
 
 // SaveGeolocation store the geolocation data.
-func (s *Geolocation) SaveGeolocation(ctx context.Context, geo model.Geolocation) error {
+func (s *Geolocation) SaveGeolocation(ctx context.Context, geos []*model.Geolocation) error {
 	errMsg := "storage.Geolocation: failed to save Geolocation"
 
-	q := s.storage.InsertStmt(GeolocationTable, geo)
+	q := s.storage.InsertStmt(GeolocationTable, geos)
 
 	_, err := s.storage.Exec(ctx, q)
 	if err == nil {

--- a/internal/platform/storage/geolocation_test.go
+++ b/internal/platform/storage/geolocation_test.go
@@ -49,7 +49,7 @@ func TestGeolocation_SaveGeolocation_success(t *testing.T) {
 
 	s := storage.NewGeolocation(st)
 
-	err = s.SaveGeolocation(context.Background(), geo)
+	err = s.SaveGeolocation(context.Background(), []*model.Geolocation{&geo})
 	require.NoError(t, err)
 
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -89,9 +89,76 @@ func TestGeolocation_SaveGeolocation_failure(t *testing.T) {
 
 	s := storage.NewGeolocation(st)
 
-	err = s.SaveGeolocation(context.Background(), geo)
+	err = s.SaveGeolocation(context.Background(), []*model.Geolocation{&geo})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "error")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGeolocation_SaveGeolocation_batch(t *testing.T) {
+	t.Parallel()
+
+	// Load sample data
+	data, err := helpers.LoadSampleData(3, 0)
+	require.NoError(t, err)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	var geos []*model.Geolocation
+
+	geo1, err := model.DecodeGeolocation(data[0])
+	require.NoError(t, err)
+
+	geos = append(geos, &geo1)
+
+	geo2, err := model.DecodeGeolocation(data[1])
+	require.NoError(t, err)
+
+	geos = append(geos, &geo2)
+
+	geo3, err := model.DecodeGeolocation(data[2])
+	require.NoError(t, err)
+
+	geos = append(geos, &geo3)
+
+	mock.ExpectExec(`
+		INSERT INTO geolocation (ip_address,country_code,country,city,latitude,longitude,mystery_value) 
+			VALUES ($1,$2,$3,$4,$5,$6,$7),($8,$9,$10,$11,$12,$13,$14),($15,$16,$17,$18,$19,$20,$21)
+		`).
+		WithArgs(
+			geo1.IPAddress,
+			geo1.CountryCode,
+			geo1.Country,
+			geo1.City,
+			geo1.Latitude,
+			geo1.Longitude,
+			geo1.MysteryValue,
+			geo2.IPAddress,
+			geo2.CountryCode,
+			geo2.Country,
+			geo2.City,
+			geo2.Latitude,
+			geo2.Longitude,
+			geo2.MysteryValue,
+			geo3.IPAddress,
+			geo3.CountryCode,
+			geo3.Country,
+			geo3.City,
+			geo3.Latitude,
+			geo3.Longitude,
+			geo3.MysteryValue,
+		).
+		WillReturnResult(sqlmock.NewResult(3, 3))
+
+	st := sqluct.NewStorage(sqlx.NewDb(db, "sqlmock"))
+
+	s := storage.NewGeolocation(st)
+
+	err = s.SaveGeolocation(context.Background(), geos)
+	require.NoError(t, err)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/resources/migrations/20241123234427_create_geolocation_table.up.sql
+++ b/resources/migrations/20241123234427_create_geolocation_table.up.sql
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS "geolocation" (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX geolocation_ip_address_idx ON geolocation(ip_address);
+CREATE INDEX geolocation_ip_address_idx ON geolocation(ip_address);


### PR DESCRIPTION
# Description

Use the insert in batch to improve the process geolocation.

The constraint CREATE UNIQUE INDEX geolocation_ip_address_idx ON geolocation(ip_address);

**Note:** I did update the SQL in the same file just because this is a task, but the process should be create a new migration file that contains this change. For example:

```
DROP INDEX geolocation_ip_address_idx;
CREATE INDEX geolocation_ip_address_idx ON geolocation(ip_address);
```

**Using sample data:**

Before insert in batch

```
{"level":"info","timestamp":"2024-11-29T13:11:47.851+0100","message":"geolocation data processed","accepted":916605,"discarded":83395,"discarded_reasons":{"invalid ip address":16542,"missing country code":16695,"missing ip address":16980,"parsing latitude":33178},"duration_s":201.7846235}
```

After insert in batch

```
{"level":"info","timestamp":"2024-11-29T14:51:47.674+0100","message":"geolocation data processed","accepted":916605,"discarded":83395,"discarded_reasons":{"invalid ip address":16542,"missing country code":16695,"missing ip address":16980,"parsing latitude":33178},"duration_s":17.416088082999998}

```